### PR TITLE
fix: add created field to inspectTicket query and type

### DIFF
--- a/lib/services/tickets.ts
+++ b/lib/services/tickets.ts
@@ -66,6 +66,7 @@ export type TicketInspection = {
 	id: string;
 	firstName: string;
 	lastName: string;
+	created: Date;
 	status: string;
 	orderId: string;
 	createdReason?: string;
@@ -420,6 +421,7 @@ export async function inspectTicket(ticketToken: string): Promise<TicketInspecti
 				g.id,
 				g.first_name,
 				g.last_name,
+				g.created,
 				g.status,
 				g.order_id,
 				g.created_reason,


### PR DESCRIPTION
## Summary
- Added `g.created` to the `inspectTicket` SQL SELECT
- Added `created: Date` to the `TicketInspection` type

## Why
The admin Inspect page calls `format(new Date(created), ...)` to render the ticket creation date. `created` was missing from both the SQL query and the TypeScript type, so `new Date(undefined)` produced an Invalid Date and `date-fns/format()` threw — crashing the component into the ErrorBoundary on every QR scan.

## Test plan
- [ ] Scan a valid guest QR on the Inspect page — guest info renders with a correct Created date
- [ ] Scan an unknown QR — "Guest not found" message appears (no crash)
- [ ] `npm test` passes in `api/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)