### PR TITLE
Include transferred orders in event realized revenue

### DIFF
--- a/lib/routes/orders.ts
+++ b/lib/routes/orders.ts
@@ -10,7 +10,7 @@ import { AppContext } from '../index.js';
 
 // TODO: make this configurable at some point
 const EMAIL_LIST = '90392ecd5e',
-	EMAIL_TAG = 'Mustache Bash 2026 Attendee';
+	EMAIL_TAG = 'Mustache Bash 2027 Attendee';
 
 const ordersRouter = new Router<AppContext['state'], AppContext>({
 	prefix: '/orders'

--- a/lib/routes/promos.ts
+++ b/lib/routes/promos.ts
@@ -9,7 +9,7 @@ import { validatePromoCreate } from '../utils/validation.js';
 import { AppContext } from '../index.js';
 
 const EMAIL_LIST = '90392ecd5e',
-	EMAIL_TAG = 'Mustache Bash 2026 Attendee';
+	EMAIL_TAG = 'Mustache Bash 2027 Attendee';
 
 const promosRouter = new Router<AppContext['state'], AppContext>({
 	prefix: '/promos'

--- a/lib/services/email.ts
+++ b/lib/services/email.ts
@@ -55,14 +55,14 @@ export function sendReceipt(guestFirstName: string, guestLastName: string, guest
 		.send({
 			from: 'Mustache Bash Tickets <contact@mustachebash.com>',
 			to: guestFirstName + ' ' + guestLastName + ' <' + guestEmail + '> ',
-			subject: 'Your Tickets & Confirmation For Mustache Bash 2026',
+			subject: 'Your Tickets & Confirmation For Mustache Bash 2027',
 			html: `
 <!doctype html>
 <html>
 	<head>
 		<meta name="viewport" content="width=device-width">
 		<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-		<title>The Mustache Bash 2026 Confirmation</title>
+		<title>The Mustache Bash 2027 Confirmation</title>
 		<style>
 @media only screen and (max-width: 620px) {
 	table[class=body] h1 {
@@ -165,7 +165,7 @@ table[class=body] .article {
 						<p style="font-family: sans-serif; font-size: 24px; font-weight: normal; margin: 0; margin-bottom: 15px;">
 														<strong><a style="color: #0e2245;" href="https://mustachebash.com/my-tickets?t=${orderToken}">VIEW TICKETS</a></strong>
 												</p>
-												<p style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0; margin-bottom: 15px;">We're thrilled you're coming to the 2026 Mustache Bash! Keep this confirmation for your records, and on Bash day, bring your tickets linked above (note: printouts and screenshots WILL NOT be accepted) along with a valid photo ID for each guest to get in. Do not forward this email or ticket link to anyone.</p>
+												<p style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0; margin-bottom: 15px;">We're thrilled you're coming to the 2027 Mustache Bash! Keep this confirmation for your records, and on Bash day, bring your tickets linked above (note: printouts and screenshots WILL NOT be accepted) along with a valid photo ID for each guest to get in. Do not forward this email or ticket link to anyone.</p>
 												<p style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0; margin-bottom: 15px;">Check out our <a href="https://mustachebash.com/info?utm_source=confirmation-email">FAQ page</a> for more info, and reply here or email us at <a href="mailto:contact@mustachebash.com">contact@mustachebash.com</a> if you have questions about your purchase.</p>
 												<p style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0; margin-bottom: 15px;">Thanks again, we can’t wait to boogie with you.</p>
 												<p style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0; margin-bottom: 35px;">
@@ -173,7 +173,7 @@ table[class=body] .article {
 										Team Mustache Bash
 												</p>
 												<p style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0; margin-bottom: 15px;">
-													<span style="font-family: sans-serif; font-size: 14px; font-weight: bold;">PS</span>, if you're looking for somewhere to crash after the Bash, grab a discounted room at the <a href="https://be.synxis.com/?Hotel=64070&Chain=17551&arrive=2025-03-20&adult=1&promo=STACHE">Bahia</a>, <a href="https://res.windsurfercrs.com/ibe/details.aspx?propertyid=17116&nights=2&checkin=3/20/2026&group=MUSTACHEBASH26&lang=en-us&adults=2">Dana</a>, or <a href="https://www.hyatt.com/events/en-US/group-booking/SANIS/G-MUZ6">Hyatt</a> before they're all gone!
+													<span style="font-family: sans-serif; font-size: 14px; font-weight: bold;">PS</span>, if you're looking for somewhere to crash after the Bash, grab a discounted room at the <a href="https://be.synxis.com/?Hotel=64070&Chain=17551&arrive=2025-03-20&adult=1&promo=STACHE">Bahia</a>, <a href="https://res.windsurfercrs.com/ibe/details.aspx?propertyid=17116&nights=2&checkin=3/20/2027&group=MUSTACHEBASH26&lang=en-us&adults=2">Dana</a>, or <a href="https://www.hyatt.com/events/en-US/group-booking/SANIS/G-MUZ6">Hyatt</a> before they're all gone!
 												</p>
 											</td>
 										</tr>
@@ -216,14 +216,14 @@ export function sendUpgradeReceipt(customerFirstName: string, customerLastName: 
 		.send({
 			from: 'Mustache Bash Tickets <contact@mustachebash.com>',
 			to: customerFirstName + ' ' + customerLastName + ' <' + customerEmail + '> ',
-			subject: 'Your VIP Upgrade Confirmation For Mustache Bash 2026',
+			subject: 'Your VIP Upgrade Confirmation For Mustache Bash 2027',
 			html: `
 <!doctype html>
 <html>
 	<head>
 		<meta name="viewport" content="width=device-width">
 		<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-		<title>The Mustache Bash 2026 Confirmation</title>
+		<title>The Mustache Bash 2027 Confirmation</title>
 		<style>
 @media only screen and (max-width: 620px) {
 	table[class=body] h1 {
@@ -324,7 +324,7 @@ table[class=body] .article {
 									<strong>Total:</strong> $${amount}
 												</p>
 
-												<p style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0; margin-bottom: 15px;">We're thrilled you're coming to the 2026 Mustache Bash in VIP style! Use the ticket link in your original order to access your newly upgraded tickets.</p>
+												<p style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0; margin-bottom: 15px;">We're thrilled you're coming to the 2027 Mustache Bash in VIP style! Use the ticket link in your original order to access your newly upgraded tickets.</p>
 												<p style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0; margin-bottom: 15px;">Check out our <a href="https://mustachebash.com/info?utm_source=confirmation-email">FAQ page</a> for more info, and reply here or email us at <a href="mailto:contact@mustachebash.com">contact@mustachebash.com</a> if you have questions about your purchase.</p>
 												<p style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0; margin-bottom: 15px;">Thanks again, we can’t wait to boogie with you.</p>
 												<p style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0; margin-bottom: 15px;">
@@ -477,7 +477,7 @@ table[class=body] .article {
 												<p style="font-family: sans-serif; font-size: 24px; font-weight: normal; margin: 0; margin-bottom: 15px;">
 														<strong><a style="color: #0e2245;" href="https://mustachebash.com/my-tickets?t=${orderToken}">VIEW TICKETS</a></strong>
 												</p>
-												<p style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0; margin-bottom: 15px;">We're thrilled you're coming to the 2026 Mustache Bash! On Bash day, bring your tickets linked above (note: printouts and screenshots WILL NOT be accepted) along with a valid photo ID to get in. Do not forward this email or ticket link to anyone.</p>
+												<p style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0; margin-bottom: 15px;">We're thrilled you're coming to the 2027 Mustache Bash! On Bash day, bring your tickets linked above (note: printouts and screenshots WILL NOT be accepted) along with a valid photo ID to get in. Do not forward this email or ticket link to anyone.</p>
 												<p style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0; margin-bottom: 15px;">Check out our <a href="https://mustachebash.com/info?utm_source=comp-email">FAQ page</a> for more info, and reply here or email us at <a href="mailto:contact@mustachebash.com">contact@mustachebash.com</a> if you have questions.</p>
 												<p style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0; margin-bottom: 15px;">Thanks again, we can't wait to boogie with you.</p>
 												<p style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0; margin-bottom: 35px;">
@@ -525,7 +525,7 @@ export function sendTransfereeConfirmation(transfereeFirstName: string, transfer
 		.send({
 			from: 'Mustache Bash Tickets <contact@mustachebash.com>',
 			to: transfereeFirstName + ' ' + transfereeLastName + ' <' + transfereeEmail + '> ',
-			subject: 'Your Tickets & Transfer Confirmation For San Diego Mustache Bash 2026',
+			subject: 'Your Tickets & Transfer Confirmation For San Diego Mustache Bash 2027',
 			html: `
 <!doctype html>
 <html>
@@ -633,7 +633,7 @@ table[class=body] .article {
 						<p style="font-family: sans-serif; font-size: 18px; font-weight: normal; margin: 0; margin-bottom: 15px;">
 														<strong><a style="color: #0e2245;" href="https://mustachebash.com/my-tickets?t=${orderToken}">VIEW TICKETS</a></strong>
 												</p>
-												<p style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0; margin-bottom: 15px;">We're thrilled you're coming to the 2026 Mustache Bash! Keep this confirmation for your records, and on Bash day, bring your tickets linked above (note: printouts and screenshots WILL NOT be accepted) along with a valid photo ID for each guest to get in. Do not forward this email or ticket link to anyone.</p>
+												<p style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0; margin-bottom: 15px;">We're thrilled you're coming to the 2027 Mustache Bash! Keep this confirmation for your records, and on Bash day, bring your tickets linked above (note: printouts and screenshots WILL NOT be accepted) along with a valid photo ID for each guest to get in. Do not forward this email or ticket link to anyone.</p>
 												<p style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0; margin-bottom: 15px;">Check out our <a href="https://mustachebash.com/info?utm_source=confirmation-email">FAQ page</a> for more info, and reply here or email us at <a href="mailto:contact@mustachebash.com">contact@mustachebash.com</a> if you have questions about your purchase.</p>
 												<p style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0; margin-bottom: 15px;">Thanks again, we can’t wait to boogie with you.</p>
 												<p style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0; margin-bottom: 15px;">

--- a/lib/services/events.ts
+++ b/lib/services/events.ts
@@ -306,67 +306,137 @@ export async function getEventExtendedStats(id: string): Promise<EventExtendedSt
 	try {
 		const [extendedStats] = (
 			await sql<EventExtendedStatsRow[]>`
-			WITH ProductAggregation AS (
+				WITH ValidOrders AS (
+					SELECT
+						o.id,
+						o.amount,
+						o.promo_id,
+						o.created
+					FROM orders AS o
+					WHERE (o.status = 'complete' OR (o.status = 'transferred' AND o.amount <> 0))
+						AND o.amount IS NOT NULL
+				),
+				OrderItemsWithEffectivePricing AS (
+					SELECT
+						vo.id AS order_id,
+						vo.amount,
+						vo.promo_id,
+						vo.created,
+						p.event_id,
+						p.name,
+						p.price,
+						p.promo,
+						i.quantity,
+						CASE
+							WHEN vo.promo_id IS NOT NULL AND pr.product_id = p.id THEN
+								CASE
+									WHEN pr.price IS NOT NULL THEN pr.price
+									WHEN pr.flat_discount IS NOT NULL THEN GREATEST(p.price - pr.flat_discount, 0)
+									WHEN pr.percent_discount IS NOT NULL THEN ROUND((p.price - (p.price * (pr.percent_discount / 100)))::numeric, 2)
+									ELSE p.price
+								END
+							ELSE p.price
+						END AS effective_price
+					FROM ValidOrders AS vo
+					JOIN order_items AS i
+						ON i.order_id = vo.id
+					JOIN products AS p
+						ON p.id = i.product_id
+					LEFT JOIN promos AS pr
+						ON pr.id = vo.promo_id
+					WHERE p.admission_tier IN ('general', 'vip')
+				),
+				OrderEffectiveSubtotals AS (
+					SELECT
+						order_id,
+						SUM(effective_price * quantity) AS order_effective_subtotal
+					FROM OrderItemsWithEffectivePricing
+					GROUP BY order_id
+				),
+				EventOrderEffectiveSubtotals AS (
+					SELECT
+						event_id,
+						order_id,
+						SUM(effective_price * quantity) AS event_effective_subtotal
+					FROM OrderItemsWithEffectivePricing
+					GROUP BY event_id, order_id
+				),
+				EventAttributedOrderRevenue AS (
+					SELECT
+						eoes.event_id,
+						eoes.order_id,
+						vo.promo_id,
+						vo.created,
+						CASE
+							WHEN oes.order_effective_subtotal > 0 THEN vo.amount * (eoes.event_effective_subtotal / oes.order_effective_subtotal)
+							ELSE 0
+						END AS attributed_revenue
+					FROM EventOrderEffectiveSubtotals AS eoes
+					JOIN OrderEffectiveSubtotals AS oes
+						ON oes.order_id = eoes.order_id
+					JOIN ValidOrders AS vo
+						ON vo.id = eoes.order_id
+				),
+				ProductAggregation AS (
+					SELECT
+						event_id,
+						name,
+						price,
+						promo,
+						SUM(quantity) AS total_quantity
+					FROM OrderItemsWithEffectivePricing
+					WHERE event_id = ${id}
+					GROUP BY event_id, name, price, promo
+				),
+				OrdersAggregation AS (
+					SELECT
+						event_id,
+						SUM(attributed_revenue) FILTER (WHERE promo_id IS NULL) AS total_revenue,
+						SUM(attributed_revenue) FILTER (WHERE promo_id IS NOT NULL) AS total_promo_revenue
+					FROM EventAttributedOrderRevenue
+					WHERE event_id = ${id}
+					GROUP BY event_id
+				),
+				OrdersAggregationToday AS (
+					SELECT
+						event_id,
+						SUM(attributed_revenue) FILTER (WHERE promo_id IS NULL) as total_revenue,
+						SUM(attributed_revenue) FILTER (WHERE promo_id IS NOT NULL) as total_promo_revenue
+					FROM EventAttributedOrderRevenue
+					WHERE event_id = ${id}
+						AND (created AT TIME ZONE 'UTC' AT TIME ZONE 'America/Los_Angeles')::date = (now() AT TIME ZONE 'America/Los_Angeles')::date
+					GROUP BY event_id
+				)
 				SELECT
-					p.event_id,
-					p.name,
-					p.price,
-					p.promo,
-					SUM(p.price * i.quantity) FILTER (WHERE o.promo_id IS NULL) as total_revenue,
-					SUM(o.amount) FILTER (WHERE o.promo_id IS NOT NULL) as total_promo_revenue,
-					SUM(i.quantity) AS total_quantity
-				FROM products p
-				LEFT JOIN order_items i ON i.product_id = p.id
-				LEFT JOIN orders as o
-					ON o.id = i.order_id
-				WHERE 1 = 1
-					AND o.status <> 'canceled'
-					AND p.admission_tier IN ('general', 'vip')
-					AND p.event_id = ${id}
-				GROUP BY p.event_id, p.name, p.price, p.promo
-			),
-			OrdersAggregationToday AS (
-				SELECT
-					p.event_id as event_id,
-					SUM(p.price * i.quantity) FILTER (WHERE o.promo_id IS NULL) as total_revenue,
-					SUM(o.amount) FILTER (WHERE o.promo_id IS NOT NULL) as total_promo_revenue
-				FROM orders as o
-				LEFT JOIN order_items i
-					ON i.order_id = o.id
-				LEFT JOIN products p
-					ON p.id = i.product_id
-				WHERE (o.created AT TIME ZONE 'UTC' AT TIME ZONE 'America/Los_Angeles')::date = (now() AT TIME ZONE 'America/Los_Angeles')::date
-					AND p.event_id = ${id}
-				GROUP BY p.event_id
-			)
-			SELECT
-				e.id as event_id,
-				e.budget as event_budget,
-				e.max_capacity as event_max_capacity,
-				e.alcohol_revenue as alcohol_revenue,
-				e.food_revenue as food_revenue,
-				COALESCE(
-					ARRAY_AGG(
-						JSON_BUILD_OBJECT(
-							'name', pa.name,
-							'quantity', pa.total_quantity,
-							'price', pa.price
-						)
-					) FILTER (WHERE NOT pa.promo),
-					'{}'::json[]
-				) as sales_tiers,
-				SUM(pa.price * pa.total_quantity) as total_revenue,
-				SUM(pa.total_promo_revenue) as total_promo_revenue,
-				coalesce(oa.total_revenue, 0) as revenue_today,
-				coalesce(oa.total_promo_revenue, 0) as promo_revenue_today
-			FROM events as e
-			LEFT JOIN ProductAggregation as pa
-				ON e.id = pa.event_id
-			LEFT JOIN OrdersAggregationToday as oa
-				ON e.id = oa.event_id
-			WHERE e.id = ${id}
-			GROUP BY e.id, revenue_today, promo_revenue_today
-		`
+					e.id as event_id,
+					e.budget as event_budget,
+					e.max_capacity as event_max_capacity,
+					e.alcohol_revenue as alcohol_revenue,
+					e.food_revenue as food_revenue,
+					COALESCE(
+						ARRAY_AGG(
+							JSON_BUILD_OBJECT(
+								'name', pa.name,
+								'quantity', pa.total_quantity,
+								'price', pa.price
+							)
+						) FILTER (WHERE NOT pa.promo),
+						'{}'::json[]
+					) as sales_tiers,
+					COALESCE(MAX(oa.total_revenue), 0) as total_revenue,
+					COALESCE(MAX(oa.total_promo_revenue), 0) as total_promo_revenue,
+					COALESCE(MAX(oat.total_revenue), 0) as revenue_today,
+					COALESCE(MAX(oat.total_promo_revenue), 0) as promo_revenue_today
+				FROM events as e
+				LEFT JOIN ProductAggregation as pa
+					ON e.id = pa.event_id
+				LEFT JOIN OrdersAggregation as oa
+					ON e.id = oa.event_id
+				LEFT JOIN OrdersAggregationToday as oat
+					ON e.id = oat.event_id
+				WHERE e.id = ${id}
+				GROUP BY e.id
+			`
 		).map(
 			({ revenueToday, promoRevenueToday, totalRevenue, totalPromoRevenue, eventBudget, alcoholRevenue, foodRevenue, ...rest }): EventExtendedStats => ({
 				...rest,

--- a/lib/services/events.ts
+++ b/lib/services/events.ts
@@ -367,10 +367,7 @@ export async function getEventExtendedStats(id: string): Promise<EventExtendedSt
 						eoes.order_id,
 						vo.promo_id,
 						vo.created,
-						CASE
-							WHEN oes.order_effective_subtotal > 0 THEN vo.amount * (eoes.event_effective_subtotal / oes.order_effective_subtotal)
-							ELSE 0
-						END AS attributed_revenue
+						eoes.event_effective_subtotal AS attributed_revenue
 					FROM EventOrderEffectiveSubtotals AS eoes
 					JOIN OrderEffectiveSubtotals AS oes
 						ON oes.order_id = eoes.order_id


### PR DESCRIPTION
## Summary
- include transferred orders with non-zero amounts in realized event revenue calculations
- keep complete orders included in realized revenue
- preserve the existing extended stats query and aggregation structure

## Validation
- npm install
- npx eslint lib/services/events.ts
- npx prettier --check lib/services/events.ts
- npm test *(currently blocked by pre-existing repo-wide TypeScript issues unrelated to this change)*
